### PR TITLE
[feat] Journal 엔티티에 그림일기 저장 후 s3 업로드 - 1차 구현

### DIFF
--- a/src/main/java/com/hack/hack_server/ChatGpt/Dto/DalleAnswerResponseDto.java
+++ b/src/main/java/com/hack/hack_server/ChatGpt/Dto/DalleAnswerResponseDto.java
@@ -1,0 +1,16 @@
+package com.hack.hack_server.ChatGpt.Dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DalleAnswerResponseDto {
+    private String answer;
+    private Long jourId;
+
+    public DalleAnswerResponseDto(String answer, Long jourId){
+        this.answer = answer;
+        this.jourId = jourId;
+    }
+}

--- a/src/main/java/com/hack/hack_server/ChatGpt/Service/MockMultipartFile.java
+++ b/src/main/java/com/hack/hack_server/ChatGpt/Service/MockMultipartFile.java
@@ -1,0 +1,58 @@
+package com.hack.hack_server.ChatGpt.Service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class MockMultipartFile implements MultipartFile {
+    String fileName;
+    byte[] bytes;
+
+    public MockMultipartFile(String fileName, byte[] bytes) {
+        this.fileName= fileName;
+        this.bytes = bytes;
+    }
+
+    @Override
+    public String getName() {
+        return fileName;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return null;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public long getSize() {
+        return 0;
+    }
+
+    @Override
+    public byte[] getBytes() throws IOException {
+        return bytes;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new ByteArrayInputStream(bytes);
+    }
+
+    @Override
+    public void transferTo(File dest) throws IOException, IllegalStateException {
+
+    }
+}

--- a/src/main/java/com/hack/hack_server/Dalle/Controller/ImageGeneratorController.java
+++ b/src/main/java/com/hack/hack_server/Dalle/Controller/ImageGeneratorController.java
@@ -1,16 +1,26 @@
 package com.hack.hack_server.Dalle.Controller;
 
 import com.hack.hack_server.Authentication.PrincipalDetails;
+import com.hack.hack_server.ChatGpt.Dto.DalleAnswerResponseDto;
 import com.hack.hack_server.ChatGpt.Dto.QuestionRequestDto;
 import com.hack.hack_server.ChatGpt.Service.ChatGptService;
+import com.hack.hack_server.ChatGpt.Service.MockMultipartFile;
 import com.hack.hack_server.Dalle.Service.AIService;
+import com.hack.hack_server.Global.S3.S3Uploader;
 import com.hack.hack_server.Papago.NaverTransService;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.binary.Base64;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import com.hack.hack_server.ChatGpt.Dto.ChatGptAnswerResponseDto;
+import org.springframework.web.multipart.MultipartFile;
+
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/journal")
@@ -20,14 +30,56 @@ public class ImageGeneratorController {
     private final AIService aiService;
     private final NaverTransService naverTransService;
     private final ChatGptService chatGptService;
+    private final S3Uploader s3Uploader;
 
 
-//    @PostMapping("/{pet_id}")
-//    public ChatGptAnswerResponseDto sendQuestion(@PathVariable Long pet_id, @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        ////requestDto 내용으로 "일기를 써줘."가 들어가고, 그 일기 내용이 아래의 Prompt로 들어가야함!
-//        return chatGptService.generateJournal(pet_id, principalDetails);
-//    }
+    //메인 기능: 그림일기(글+그림) 생성 후 s3에 저장
+    @PostMapping("/{pet_id}/image")
+    public ResponseEntity<?> generateImage(@PathVariable Long pet_id, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        DalleAnswerResponseDto dalleAnswerResponseDto = chatGptService.generateJournal(pet_id, principalDetails); //chatGPT: 그림일기 생성 (글)
+        Long jourId = dalleAnswerResponseDto.getJourId();
+        String koJournal = dalleAnswerResponseDto.getAnswer();
 
+        String shortKoJour = chatGptService.shortJorunal(koJournal).getAnswer(); //DALL-E에게 전달을 위한 1문장 요약
+
+        String img = aiService.generatePicture(naverTransService.getTransSentence(shortKoJour)); // papago를 거쳐 DALL-E를 통해 반환된 b64_json String
+        chatGptService.generateImage(pet_id, principalDetails, img, jourId); //DB에 그림일기 저장!
+
+        byte[] image = Base64.decodeBase64(img); //b64 string -> byte[]
+
+
+        int totalCnt = 1024;
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(totalCnt)) {
+            int offset = 0;
+            while (offset < image.length) {
+                int chunkSize = Math.min(totalCnt, image.length - offset);
+
+                byte[] byteArray = new byte[chunkSize];
+                System.arraycopy(image, offset, byteArray, 0, chunkSize);
+
+                byteArrayOutputStream.write(byteArray);
+                byteArrayOutputStream.flush();
+
+                offset += chunkSize;
+            }
+
+            // Convert the ByteArrayOutputStream to ByteArrayInputStream
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+
+            // Create an MultipartFile object
+            MultipartFile multipartFile = new MockMultipartFile("그림 일기", byteArrayInputStream.readAllBytes());
+
+            s3Uploader.saveFile(multipartFile); //s3에 멀티파트 파일로 직접 업로드! => ok.
+
+        } catch (IOException e) {
+        }
+
+        return new ResponseEntity<>(img, HttpStatus.OK);
+    }
+
+
+
+    //chatGPT & papago api 테스트
     @PostMapping("/{pet_id}")
     public String sendQuestion(@PathVariable Long pet_id, @AuthenticationPrincipal PrincipalDetails principalDetails) {
         //requestDto 내용으로 "일기를 써줘."가 들어가고, 그 일기 내용이 아래의 Prompt로 들어가야함!
@@ -38,26 +90,12 @@ public class ImageGeneratorController {
     }
 
 
-    //[기능: 일기 훔쳐보기]
-//    @PostMapping("/image")
-//    public ResponseEntity<?> generateImage(@RequestBody String prompt) {
-////        System.out.print(naverTransService.getTransSentence(prompt)); //Papago API 정상 작동 확인
-//        return new ResponseEntity<>(aiService.generatePicture(naverTransService.getTransSentence(prompt)), HttpStatus.OK);
-//    }
-
-    @PostMapping("/{pet_id}/image")
-    public ResponseEntity<?> generateImage(@PathVariable Long pet_id, @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        String koJournal = chatGptService.generateJournal(pet_id, principalDetails).getAnswer();
-        String shortKoJour = chatGptService.shortJorunal(koJournal).getAnswer(); //DALL-E에게 전달을 위한 1문장 요약
-        System.out.print(shortKoJour);
-        return new ResponseEntity<>(aiService.generatePicture(naverTransService.getTransSentence(shortKoJour)), HttpStatus.OK);
-    }
-
 
     //DALL-E api 테스트
     @PostMapping("/image")
     public ResponseEntity<?> generateImage(@RequestBody String prompt) {
         return new ResponseEntity<>(aiService.generatePicture(prompt), HttpStatus.OK);
     }
+
 
 }

--- a/src/main/java/com/hack/hack_server/Dalle/Service/AIService.java
+++ b/src/main/java/com/hack/hack_server/Dalle/Service/AIService.java
@@ -18,9 +18,13 @@ public class AIService {
                 .prompt(prompt)
                 .size("512x512")
                 .n(1)
+                .responseFormat("b64_json") //b64_json 포맷으로의 반환을 위해 이 코드 추가!
                 .build();
 
-        String url = openAiService.createImage(createImageRequest).getData().get(0).getUrl();
-        return url;
+//        String url = openAiService.createImage(createImageRequest).getData().get(0).getUrl();
+
+        //이미지 URL 대신 base64-encoded JSON을 리턴하는 것으로 변경!
+        String b64 = openAiService.createImage(createImageRequest).getData().get(0).getB64Json();
+        return b64;
     }
 }

--- a/src/main/java/com/hack/hack_server/Dalle/ServicesConfig.java
+++ b/src/main/java/com/hack/hack_server/Dalle/ServicesConfig.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
+
 @Configuration
 public class ServicesConfig {
     @Value("${app.openai.api}")
@@ -13,6 +15,8 @@ public class ServicesConfig {
 
     @Bean
     public OpenAiService getOpenAiService() {
-        return new OpenAiService(apiKey);
+        //socket timeout ERROR 해결:
+        return new OpenAiService(apiKey, Duration.ofSeconds(30));
+//        return new OpenAiService(apiKey);
     }
 }

--- a/src/main/java/com/hack/hack_server/Global/S3/S3ImageController.java
+++ b/src/main/java/com/hack/hack_server/Global/S3/S3ImageController.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 

--- a/src/main/java/com/hack/hack_server/Repository/JournalRepository.java
+++ b/src/main/java/com/hack/hack_server/Repository/JournalRepository.java
@@ -2,12 +2,21 @@ package com.hack.hack_server.Repository;
 
 import com.hack.hack_server.Entity.Journal;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Repository
 public interface JournalRepository extends JpaRepository<Journal, Long> {
+    @Query(nativeQuery = true, value = "select * from journal where pet_id=:pet_id and owner_id=:owner_id")
+    Journal findByPetAndOwnerId(@Param("pet_id") Long petId, @Param("owner_id") Long owner_id);
 
+    @Transactional
+    @Modifying
+    @Query(nativeQuery = true, value = "update journal j set j.image=:image where journal_id=:journal_id")
+    int updateImage(@Param("journal_id") Long journalId, @Param("image") String image);
 }


### PR DESCRIPTION
### 완료한 부분
- chatGPT -> DB에 일기 저장 -> chatGPT(일기 1문장으로 요약) -> Papago -> DALL-E -> DB에 그림 일기 (b64_json String 형태로 저장)
- MultipartFile (MockMultipartFile 이용) 형태로 s3 버킷에 객체 업로드

### 수정이 필요한 부분
- b64_json -> byte[] -> MultiPartFile (MockMultipartFile 이용)
이 과정에서 의도한 byte[] 데이터, 즉 DB 내에 있는 b64_json string이 변환된 byte[] 데이터가 제대로 MultipartFile로 변환되지 못한 것 같다!